### PR TITLE
Fix pushGateway options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Configuration of targets can be done via docker and via prometheus
 | -t               | NONE               | multi-value target array (check docker comp)  |                    | False    |
 | -listener        | PAGESPEED_LISTENER | sets the listener address for the exporters   | :9271              | False    |
 | -parallel        | PAGESPEED_PARALLEL | sets the execution of targets to be parallel  | false              | False    |
-| -pushgateway-url | PUSHGATEWAY_URL    | sets the pushgateway url to send the metrics  |                    | False    |
-| -pushgateway-job | PUSHGATEWAY_JOB    | sets the pushgateway job name                 | pagespeed_exporter | False    |
+| -pushGatewayUrl  | PUSHGATEWAY_URL    | sets the pushgateway url to send the metrics  |                    | False    |
+| -pushGatewayJob  | PUSHGATEWAY_JOB    | sets the pushgateway job name                 | pagespeed_exporter | False    |
 
 Note: google api key is required only if scraping more than 2 targets/second
 


### PR DESCRIPTION
Ref:
```
Usage of pagespeed_exporter:
  -api-key string
    	sets the google API key used for pagespeed
  -listener string
    	sets the listener address for the exporters (default ":9271")
  -parallel
    	forces parallel execution for pagespeed
  -pushGatewayJob string
    	sets push gateway job name (default "pagespeed_exporter")
  -pushGatewayUrl string
    	sets the push gateway to send the metrics. leave empty to ignore it
  -t value
    	multiple argument parameters
  -targets string
    	comma separated list of targets to measure
```