### PR TITLE
Change of PrometheusTimeoutHeader const.

### DIFF
--- a/handler/probe.go
+++ b/handler/probe.go
@@ -18,7 +18,7 @@ import (
 const (
 	DefaultTimeoutDuration  = 30 * time.Second
 	DefaultTimeOffset       = 500 * time.Millisecond // To Allow For Processing Time
-	PrometheusTimeoutHeader = "X-Prometheus-ScrapeResult-Timeout-Seconds"
+	PrometheusTimeoutHeader = "X-Prometheus-Scrape-Timeout-Seconds"
 )
 
 type httpProbeHandler struct {


### PR DESCRIPTION
It seems that Prometheus now uses different timeout header name (https://github.com/prometheus/prometheus/blob/master/scrape/scrape.go#L610) than the one read by pagespeed_exporter (https://github.com/foomo/pagespeed_exporter/blob/master/handler/probe.go#L21). It causes failures of scrape for slower pages since the default timeout is 30s and it's not changed by Prometheus "scrape_timeout" configuration. This pull request fixes the issue.